### PR TITLE
Implement MMVv1 instance metrics

### DIFF
--- a/examples/physical.rs
+++ b/examples/physical.rs
@@ -42,7 +42,7 @@ fn main() {
     /* create a client, register the metrics with it, and export them */
 
     Client::new("physical_metrics").unwrap()
-        .begin(3).unwrap()
+        .begin(0, 0, 3).unwrap()
         .register_metric(&mut freq).unwrap()
         .register_metric(&mut color).unwrap()
         .register_metric(&mut photons).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,20 @@ extern crate time;
 #[cfg(windows)] extern crate kernel32;
 
 const CLUSTER_ID_BIT_LEN: usize = 12;
-const NUMERIC_VALUE_SIZE: usize = 8;
+const ITEM_BIT_LEN: usize = 10;
+const INDOM_BIT_LEN: usize = 22;
+
 const HDR_LEN: u64 = 40;
 const TOC_BLOCK_LEN: u64 = 16;
+const INDOM_BLOCK_LEN: u64 = 32;
+const INSTANCE_BLOCK_LEN: u64 = 80;
 const METRIC_BLOCK_LEN: u64 = 104;
 const VALUE_BLOCK_LEN: u64 = 32;
+const NUMERIC_VALUE_SIZE: usize = 8;
 const STRING_BLOCK_LEN: u64 = 256;
+
 const METRIC_NAME_MAX_LEN: u64 = 64;
 const MAX_STRINGS_PER_METRIC: u64 = 3;
-const TOC_BLOCK_COUNT: u64 = 3;
 
 type Endian = byteorder::LittleEndian;
 


### PR DESCRIPTION
Apart from implementing instance metrics, this also includes some cleanup/refactoring of singleton metric writing in order to improve code reuse.