### PR TITLE
Implement instance metrics with explicit indoms

### DIFF
--- a/examples/acme.rs
+++ b/examples/acme.rs
@@ -1,0 +1,85 @@
+extern crate hornet; 
+extern crate rand;
+
+use hornet::client::Client;
+use hornet::client::metric::*;
+use rand::random;
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+
+    let products = ["Anvils", "Rockets", "Giant_Rubber_Bands"];
+    let indom = Indom::new(
+        &products,
+        "Acme products",
+        "Most popular products produced by the Acme Corporation"
+    );
+    
+    /* create three instance metrics */
+
+    let mut counts = InstanceMetric::new(
+        &indom,
+        "products.count",
+        0,
+        Semantics::Counter,
+        Unit::new().count(Count::One, 1).unwrap(),
+        "Acme factory product throughput",
+        "Monotonic increasing counter of products produced in the Acme Corporation\nfactory since starting the Acme production application. Quality guaranteed."
+    ).unwrap();
+
+    let sec_unit = Unit::new().time(Time::Sec, 1).unwrap();
+
+    let mut times = InstanceMetric::new(
+        &indom,
+        "products.time",
+        0,
+        Semantics::Counter,
+        sec_unit,
+        "Machine time spent producing Acme products",
+        "Machine time spent producing Acme Corporation products. Does not include\ntime in queues waiting for production machinery."
+    ).unwrap();
+
+    let mut queue_times = InstanceMetric::new(
+        &indom,
+        "products.queuetime",
+        0,
+        Semantics::Counter,
+        sec_unit,
+        "Queued time while producing Acme products",
+        "Time spent in the queue waiting to build Acme Corporation products,\nwhile some other Acme product was being built instead of this one."
+    ).unwrap();
+
+    /* create a client, register the metrics with it, and export them */
+
+    Client::new("acme").unwrap()
+        .begin(1, 3, 9).unwrap()
+        .register_instance_metric(&mut counts).unwrap()
+        .register_instance_metric(&mut times).unwrap()
+        .register_instance_metric(&mut queue_times).unwrap()
+        .export().unwrap();
+
+    /* update metrics */
+
+    loop {
+        let rnd_idx = random::<usize>() % products.len();
+        let product = products[rnd_idx];
+        let working_time = random::<u64>() % 3;
+        thread::sleep(Duration::from_secs(working_time));
+
+        let count = counts.val(product).unwrap();
+        counts.set_val(product, count + 1).unwrap().unwrap();
+
+        let time = times.val(product).unwrap();
+        times.set_val(product, time + 1).unwrap().unwrap();
+
+        for i in 0..products.len() {
+            if i != rnd_idx {
+                let queued_product = products[i];
+
+                let queue_time = queue_times.val(queued_product).unwrap();
+                queue_times.set_val(queued_product, queue_time + 1).unwrap().unwrap();
+            }
+        }
+    }
+}

--- a/examples/acme.rs
+++ b/examples/acme.rs
@@ -53,7 +53,7 @@ fn main() {
     /* create a client, register the metrics with it, and export them */
 
     Client::new("acme").unwrap()
-        .begin(1, 3, 9).unwrap()
+        .begin_all(1, 3, 3, 0).unwrap()
         .register_instance_metric(&mut counts).unwrap()
         .register_instance_metric(&mut times).unwrap()
         .register_instance_metric(&mut queue_times).unwrap()

--- a/examples/acme.rs
+++ b/examples/acme.rs
@@ -14,7 +14,7 @@ fn main() {
         &products,
         "Acme products",
         "Most popular products produced by the Acme Corporation"
-    );
+    ).unwrap();
     
     /* create three instance metrics */
 

--- a/examples/physical.rs
+++ b/examples/physical.rs
@@ -42,7 +42,7 @@ fn main() {
     /* create a client, register the metrics with it, and export them */
 
     Client::new("physical_metrics").unwrap()
-        .begin(3).unwrap()
+        .begin(0, 0, 3).unwrap()
         .register_metric(&mut freq).unwrap()
         .register_metric(&mut color).unwrap()
         .register_metric(&mut photons).unwrap()

--- a/examples/physical.rs
+++ b/examples/physical.rs
@@ -42,7 +42,7 @@ fn main() {
     /* create a client, register the metrics with it, and export them */
 
     Client::new("physical_metrics").unwrap()
-        .begin(0, 0, 3).unwrap()
+        .begin_metrics(3).unwrap()
         .register_metric(&mut freq).unwrap()
         .register_metric(&mut color).unwrap()
         .register_metric(&mut photons).unwrap()

--- a/src/client/metric.rs
+++ b/src/client/metric.rs
@@ -298,6 +298,7 @@ impl<T: MetricType + Clone> Metric<T> {
 }
 
 #[derive(Clone)]
+/// An instance domain is a set of instances
 pub struct Indom {
     pub (super) instances: HashSet<String>,
     pub (super) id: u32,
@@ -306,6 +307,7 @@ pub struct Indom {
 }
 
 impl Indom {
+    /// Creates a new instance domain with given instances, and short and long help text
     pub fn new(instances: &[&str], shorthelp_text: &str, longhelp_text: &str) -> Self {
         let mut hasher = DefaultHasher::new();
         instances.hash(&mut hasher);
@@ -318,10 +320,12 @@ impl Indom {
         }
     }
 
+    /// Returns the number of instances in the domain
     pub fn instance_count(&self) -> u32 {
         self.instances.len() as u32
     }
 
+    /// Checks if given instance is in the domain
     pub fn has_instance(&self, instance: &str) -> bool {
         self.instances.contains(instance)
     }
@@ -336,12 +340,17 @@ impl Indom {
     }
 }
 
+/// An instance metric is a set of related metrics with same
+/// type, semantics and unit. Many instance metrics can share
+/// the same set of instances, i.e., instance domain.
 pub struct InstanceMetric<T> {
     pub (super) indom: Indom,
     pub (super) metrics: HashMap<String, Metric<T>>,
 }
 
 impl<T: MetricType + Clone> InstanceMetric<T> {
+    /// Creates an instance metric with given name, initial value,
+    /// semantics, unit, and short and long help text
     pub fn new(
         indom: &Indom,
         name: &str,
@@ -371,18 +380,23 @@ impl<T: MetricType + Clone> InstanceMetric<T> {
         })
     }
 
+    /// Returns the number of instances that're part of the metric
     pub fn instance_count(&self) -> u32 {
         self.metrics.len() as u32
     }
 
+    /// Check if given instance is part of the metric
     pub fn has_instance(&self, instance: &str) -> bool {
         self.metrics.contains_key(instance)
     }
 
+    /// Returns the value of the given instance
     pub fn val(&self, instance: &str) -> Option<T> {
         self.metrics.get(instance).map(|m| m.val())
     }
 
+    /// Sets the value of the given instance. If the instance isn't
+    /// found, returns `None`.
     pub fn set_val(&mut self, instance: &str, val: T) -> Option<io::Result<()>>  {
         self.metrics.get_mut(instance)
             .map(|m| m.set_val(val))

--- a/src/client/metric.rs
+++ b/src/client/metric.rs
@@ -361,9 +361,13 @@ impl<T: MetricType + Clone> InstanceMetric<T> {
         longhelp_text: &str) -> Result<Self, String> {
 
         let mut metrics = HashMap::new();
-        for inst in &indom.instances {
+
+        let mut metric_name = name.to_owned();
+        metric_name.push('.');
+        for instance in &indom.instances {
+            metric_name.push_str(instance);
             let mut metric = Metric::new(
-                &name,
+                &metric_name,
                 init_val.clone(),
                 sem,
                 unit,
@@ -371,7 +375,9 @@ impl<T: MetricType + Clone> InstanceMetric<T> {
                 longhelp_text
             )?;
             metric.indom = indom.id;
-            metrics.insert(inst.to_owned(), metric);
+            metrics.insert(instance.to_owned(), metric);
+
+            metric_name.truncate(name.len() + 1);
         }
         
         Ok(InstanceMetric {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -23,7 +23,7 @@ use super::{
     STRING_BLOCK_LEN,
     NUMERIC_VALUE_SIZE,
     METRIC_NAME_MAX_LEN,
-    MAX_STRINGS_PER_METRIC,
+    MIN_STRINGS_PER_METRIC,
     INDOM_BLOCK_LEN,
     INSTANCE_BLOCK_LEN
 };
@@ -292,9 +292,12 @@ impl Client {
             self.wi.n_instances*INSTANCE_BLOCK_LEN +
             self.wi.n_metric_blks*(
                 METRIC_BLOCK_LEN +
-                MAX_STRINGS_PER_METRIC*STRING_BLOCK_LEN
+                MIN_STRINGS_PER_METRIC*STRING_BLOCK_LEN
             ) +
-            self.wi.n_value_blks*VALUE_BLOCK_LEN
+            self.wi.n_value_blks*(
+                VALUE_BLOCK_LEN +
+                STRING_BLOCK_LEN
+            )
         ) as usize;
         
         let mut file = OpenOptions::new().read(true).write(true).create(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ const NUMERIC_VALUE_SIZE: usize = 8;
 const STRING_BLOCK_LEN: u64 = 256;
 
 const METRIC_NAME_MAX_LEN: u64 = 64;
-const MAX_STRINGS_PER_METRIC: u64 = 3;
+const MIN_STRINGS_PER_METRIC: u64 = 2;
 
 type Endian = byteorder::LittleEndian;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,15 +9,20 @@ extern crate time;
 #[cfg(windows)] extern crate kernel32;
 
 const CLUSTER_ID_BIT_LEN: usize = 12;
-const NUMERIC_VALUE_SIZE: usize = 8;
+const ITEM_BIT_LEN: usize = 10;
+const INDOM_BIT_LEN: usize = 22;
+
 const HDR_LEN: u64 = 40;
 const TOC_BLOCK_LEN: u64 = 16;
+const INDOM_BLOCK_LEN: u64 = 32;
+const INSTANCE_BLOCK_LEN: u64 = 80;
 const METRIC_BLOCK_LEN: u64 = 104;
 const VALUE_BLOCK_LEN: u64 = 32;
+const NUMERIC_VALUE_SIZE: usize = 8;
 const STRING_BLOCK_LEN: u64 = 256;
+
 const METRIC_NAME_MAX_LEN: u64 = 64;
 const MAX_STRINGS_PER_METRIC: u64 = 3;
-const TOC_BLOCK_COUNT: u64 = 3;
 
 type Endian = byteorder::LittleEndian;
 


### PR DESCRIPTION
This is a slightly more complex API which makes `Indom` explicit to the user. As opposed to https://github.com/performancecopilot/hornet/pull/20, this API allows setting of the Indom's short and long text, and also allows sharing indoms between instance metrics.

I've also added an Indom cache while writing the MMV to write only one indom block per unique `Indom`, and a string cache for constant strings as well.