### PR TITLE
Return &T in metric.val() methods

### DIFF
--- a/examples/acme.rs
+++ b/examples/acme.rs
@@ -63,17 +63,17 @@ fn main() {
         let working_time = random::<u64>() % 3;
         thread::sleep(Duration::from_secs(working_time));
 
-        let count = counts.val(product).unwrap();
+        let count = *counts.val(product).unwrap();
         counts.set_val(product, count + 1).unwrap().unwrap();
 
-        let time = times.val(product).unwrap();
+        let time = *times.val(product).unwrap();
         times.set_val(product, time + 1).unwrap().unwrap();
 
         for i in 0..products.len() {
             if i != rnd_idx {
                 let queued_product = products[i];
 
-                let queue_time = queue_times.val(queued_product).unwrap();
+                let queue_time = *queue_times.val(queued_product).unwrap();
                 queue_times.set_val(queued_product, queue_time + 1).unwrap().unwrap();
             }
         }

--- a/src/client/metric/counter.rs
+++ b/src/client/metric/counter.rs
@@ -30,12 +30,12 @@ impl Counter {
 
     /// Returns the current value of the counter
     pub fn val(&self) -> u64 {
-        self.metric.val()
+        *self.metric.val()
     }
 
     /// Increments the counter by the given value
     pub fn inc(&mut self, increment: u64) -> io::Result<()> {
-        let val = self.metric.val();
+        let val = *self.metric.val();
         self.metric.set_val(val + increment)
     }
 

--- a/src/client/metric/countvector.rs
+++ b/src/client/metric/countvector.rs
@@ -70,14 +70,14 @@ impl CountVector {
 
     /// Returns the current count of the instance
     pub fn val(&self, instance: &str) -> Option<u64> {
-        self.im.val(instance)
+        self.im.val(instance).cloned()
     }
 
     /// Increments the count of the instance by the given value
     ///
     /// The wrapping `Option` is `None` if the instance wasn't found
     pub fn inc(&mut self, instance: &str, increment: u64) -> Option<io::Result<()>> {
-        self.im.val(instance).and_then(|val|
+        self.im.val(instance).cloned().and_then(|val|
             self.im.set_val(instance, val + increment)
         )
     }
@@ -92,7 +92,7 @@ impl CountVector {
     /// Increments the count of all instances by the given value
     pub fn inc_all(&mut self, increment: u64) -> io::Result<()> {
         for instance in self.indom.instances_iter() {
-            let val = self.im.val(instance).unwrap();
+            let val = self.im.val(instance).cloned().unwrap();
             self.im.set_val(instance, val + increment).unwrap()?;
         }
         Ok(())

--- a/src/client/metric/gauge.rs
+++ b/src/client/metric/gauge.rs
@@ -30,7 +30,7 @@ impl Gauge {
 
     /// Returns the current value of the gauge
     pub fn val(&self) -> f64 {
-        self.metric.val()
+        *self.metric.val()
     }
 
     /// Sets the value of the gauge
@@ -40,13 +40,13 @@ impl Gauge {
 
     /// Increments the gauge by the given value
     pub fn inc(&mut self, increment: f64) -> io::Result<()> {
-        let val = self.metric.val();
+        let val = *self.metric.val();
         self.metric.set_val(val + increment)
     }
 
     /// Decrements the gauge by the given value
     pub fn dec(&mut self, decrement: f64) -> io::Result<()> {
-        let val = self.metric.val();
+        let val = *self.metric.val();
         self.metric.set_val(val - decrement)
     }
 

--- a/src/client/metric/gaugevector.rs
+++ b/src/client/metric/gaugevector.rs
@@ -38,7 +38,7 @@ impl GaugeVector {
 
     /// Returns the current gauge of the instance
     pub fn val(&self, instance: &str) -> Option<f64> {
-        self.im.val(instance)
+        self.im.val(instance).cloned()
     }
 
     /// Sets the gauge of the instance
@@ -50,7 +50,7 @@ impl GaugeVector {
     ///
     /// The wrapping `Option` is `None` if the instance wasn't found
     pub fn inc(&mut self, instance: &str, increment: f64) -> Option<io::Result<()>> {
-        self.im.val(instance).and_then(|val|
+        self.im.val(instance).cloned().and_then(|val|
             self.im.set_val(instance, val + increment)
         )
     }
@@ -65,7 +65,7 @@ impl GaugeVector {
     /// Increments the gauge of all instances by the given value
     pub fn inc_all(&mut self, increment: f64) -> io::Result<()> {
         for instance in self.indom.instances_iter() {
-            let val = self.im.val(instance).unwrap();
+            let val = self.im.val(instance).cloned().unwrap();
             self.im.set_val(instance, val + increment).unwrap()?;
         }
         Ok(())

--- a/src/client/metric/histogram.rs
+++ b/src/client/metric/histogram.rs
@@ -212,22 +212,22 @@ pub fn test() {
     hist.record_n(val_range.ind_sample(&mut rng), n).unwrap();
 
     assert_eq!(
-        hist.im.val(MIN_INST).unwrap(),
+        *hist.im.val(MIN_INST).unwrap(),
         hist.histogram.min() as f64
     );
 
     assert_eq!(
-        hist.im.val(MAX_INST).unwrap(),
+        *hist.im.val(MAX_INST).unwrap(),
         hist.histogram.max() as f64
     );
 
     assert_eq!(
-        hist.im.val(MEAN_INST).unwrap(),
+        *hist.im.val(MEAN_INST).unwrap(),
         hist.histogram.mean()
     );
 
     assert_eq!(
-        hist.im.val(STDEV_INST).unwrap(),
+        *hist.im.val(STDEV_INST).unwrap(),
         hist.histogram.stdev()
     );
 }

--- a/src/client/metric/mod.rs
+++ b/src/client/metric/mod.rs
@@ -532,10 +532,6 @@ pub struct Metric<T> {
     mmap_view: MmapViewSync
 }
 
-impl<T> AsMut<Metric<T>> for Metric<T> {
-    fn as_mut(&mut self) -> &mut Metric<T> { self }
-}
-
 lazy_static! {
     static ref SCRATCH_VIEW: MmapViewSync = {
         Mmap::anonymous(STRING_BLOCK_LEN as usize, Protection::ReadWrite).unwrap()
@@ -580,8 +576,8 @@ impl<T: MetricType + Clone> Metric<T> {
     }
 
     /// Returns the current value of the metric
-    pub fn val(&self) -> T {
-        self.val.clone()
+    pub fn val(&self) -> &T {
+        &self.val
     }    
 
     /// Sets the current value of the metric.
@@ -691,10 +687,6 @@ pub struct InstanceMetric<T> {
     metric: Metric<T>
 }
 
-impl<T> AsMut<InstanceMetric<T>> for InstanceMetric<T> {
-    fn as_mut(&mut self) -> &mut InstanceMetric<T> { self }
-}
-
 impl<T: MetricType + Clone> InstanceMetric<T> {
     /// Creates a new instance metric
     ///
@@ -747,8 +739,8 @@ impl<T: MetricType + Clone> InstanceMetric<T> {
     }
 
     /// Returns the value of the given instance
-    pub fn val(&self, instance: &str) -> Option<T> {
-        self.vals.get(instance).map(|i| i.val.clone())
+    pub fn val(&self, instance: &str) -> Option<&T> {
+        self.vals.get(instance).map(|i| &i.val)
     }
 
     /// Sets the value of the given instance. If the instance isn't
@@ -1131,7 +1123,7 @@ fn test_instance_metrics() {
     assert!(cache_sizes.has_instance("L1"));
     assert!(!cache_sizes.has_instance("L4"));
 
-    assert_eq!(cache_sizes.val("L2").unwrap(), 0);
+    assert_eq!(*cache_sizes.val("L2").unwrap(), 0);
     assert!(cache_sizes.val("L5").is_none());
 
     let mut cpu = Metric::new(
@@ -1146,7 +1138,7 @@ fn test_instance_metrics() {
         .export(&mut [&mut cache_sizes, &mut cpu]).unwrap();
 
     assert!(cache_sizes.set_val("L3", 8192).is_some());
-    assert_eq!(cache_sizes.val("L3").unwrap(), 8192);
+    assert_eq!(*cache_sizes.val("L3").unwrap(), 8192);
     
     assert!(cache_sizes.set_val("L4", 16384).is_none());
 }
@@ -1339,11 +1331,11 @@ fn test_random_numeric_metrics() {
             &rnd_longhelp,
         ).unwrap();
 
-        assert_eq!(metric.val(), rnd_val1);
+        assert_eq!(*metric.val(), rnd_val1);
 
         let rnd_val2 = thread_rng().gen::<u32>();
         assert!(metric.set_val(rnd_val2).is_ok());
-        assert_eq!(metric.val(), rnd_val2);
+        assert_eq!(*metric.val(), rnd_val2);
 
         metrics.push(metric);
         new_vals.push(thread_rng().gen::<u32>());

--- a/src/client/metric/timer.rs
+++ b/src/client/metric/timer.rs
@@ -80,7 +80,7 @@ impl Timer {
                     Time::Hour => duration.num_hours()
                 };
 
-                let val = self.metric.val();
+                let val = *self.metric.val();
                 self.metric.set_val(val + elapsed)?;
 
                 self.start_time = None;
@@ -94,7 +94,7 @@ impl Timer {
     /// Returns the cumulative time elapsed between every
     /// `start` and `stop` pair.
     pub fn elapsed(&mut self) -> i64 {
-        self.metric.val()
+        *self.metric.val()
     }
 }
 


### PR DESCRIPTION
We should avoid copying a string value when `val()` is called.